### PR TITLE
chore: update remirror to v2 beta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,5 @@
 .env.test.local
 .env.production.local
 
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
+*.log
+pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
   "dependencies": {
     "@emotion/react": "11.1.5",
     "@emotion/styled": "11.1.5",
-    "@remirror/pm": "latest",
-    "@remirror/react": "latest",
-    "@remirror/styles": "latest",
+    "@remirror/pm": "beta",
+    "@remirror/react": "beta",
+    "@remirror/styles": "beta",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-scripts": "4.0.3",
-    "remirror": "latest"
+    "remirror": "beta"
   },
   "devDependencies": {
     "@types/react": "17.0.0",


### PR DESCRIPTION
Currently, when open https://codesandbox.io/s/github/remirror/remirror-starter, it will show an error. I can't reproduce this error after downloading remirror-starter locally and install dependencies with npm, yarn, or pnpm. I believe this is because codesandbox cannot handle `<` in package.json, which are added by [this pull request](https://github.com/remirror/remirror/pull/1668)

![main](https://user-images.githubusercontent.com/24715727/171857369-79c6a004-b6b1-4c3b-8553-be0cb85110f1.png)

After changing the version from latest to beta, it seems to work again: 

https://codesandbox.io/s/github/remirror/remirror-starter/tree/ocavue/v2_beta

![v2-beta](https://user-images.githubusercontent.com/24715727/171857382-57f0af4f-1bbb-4e1c-b8f8-f1d0a5d45de7.png)

